### PR TITLE
chore: Add postgres docker compose volume

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,6 +5,12 @@ services:
       - /dev/sev-guest:/dev/sev-guest # for AMD SEV
     networks:
       - proxy_net
+  redis:
+    ports:
+      - "6379:6379"
+  postgres:
+    ports:
+      - "5432:5432"
   caddy:
     image: caddy:latest
     container_name: caddy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
       - .env
     networks:
       - frontend_net
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD", "sh", "-c", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB} -h localhost"]
       interval: 30s
@@ -47,7 +49,7 @@ services:
       - ${PWD}/prometheus/config/prometheus.yml:/etc/prometheus/prometheus.yml
       - ${PWD}/prometheus/data:/prometheus/data
     command: "--config.file=/etc/prometheus/prometheus.yml --storage.tsdb.retention.time=30d --web.enable-admin-api"
-    ports: 
+    ports:
       - "127.0.0.1:9090:9090"
     healthcheck:
       test: ["CMD", "wget", "http://localhost:9090/-/healthy", "-O", "/dev/null", "-o", "/dev/null"]
@@ -91,7 +93,7 @@ services:
       - .env
     environment:
       - GF_USERS_ALLOW_SIGN_UP=false
-    ports: 
+    ports:
       - "127.0.0.1:3000:3000"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
@@ -102,7 +104,7 @@ services:
 
   api:
     container_name: nilai-api
-    build: 
+    build:
       context: .
       dockerfile: docker/api.Dockerfile
       target: nilai
@@ -138,3 +140,6 @@ networks:
   # This is the network that is used for the model related services:
   ## API, models, and etcd
   backend_net:
+
+volumes:
+  postgres_data:

--- a/uv.lock
+++ b/uv.lock
@@ -1188,7 +1188,6 @@ dependencies = [
     { name = "nilai-api" },
     { name = "nilai-common" },
     { name = "nilai-models" },
-    { name = "pre-commit" },
     { name = "verifier" },
 ]
 
@@ -1196,6 +1195,7 @@ dependencies = [
 dev = [
     { name = "black" },
     { name = "isort" },
+    { name = "pre-commit" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1210,7 +1210,6 @@ requires-dist = [
     { name = "nilai-api", editable = "nilai-api" },
     { name = "nilai-common", editable = "packages/nilai-common" },
     { name = "nilai-models", editable = "nilai-models" },
-    { name = "pre-commit", specifier = ">=4.1.0" },
     { name = "verifier", editable = "packages/verifier" },
 ]
 
@@ -1218,6 +1217,7 @@ requires-dist = [
 dev = [
     { name = "black", specifier = ">=24.10.0" },
     { name = "isort", specifier = ">=5.13.2" },
+    { name = "pre-commit", specifier = ">=4.1.0" },
     { name = "pyright", specifier = ">=1.1" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-asyncio", specifier = ">=0.25.0" },


### PR DESCRIPTION
This PR adds a docker volume to postgres to prevent the loss of data if the container needs to be recreated. This is specially relevant for the `mainnet` version where data stored is relevant