### PR TITLE
feat: DB Grafana Dashboards

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -8,6 +8,7 @@ HF_TOKEN="Hugging Face API Token"
 
 ENVIRONMENT = "mainnet"
 NILAI_GUNICORN_WORKERS = 10
+NILAI_SERVER_DOMAIN = "localhost"
 
 
 # Postgres Docker Compose Config

--- a/.env.sample
+++ b/.env.sample
@@ -6,8 +6,10 @@
 # Hugging Face API Token
 HF_TOKEN="Hugging Face API Token"
 
-ENVIRONMENT = "testnet"
-NILAI_GUNICORN_WORKERS = 50
+ENVIRONMENT = "mainnet"
+NILAI_GUNICORN_WORKERS = 10
+NILAI_SERVER_DOMAIN = "localhost"
+
 
 # Postgres Docker Compose Config
 POSTGRES_HOST = "postgres"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
         run: |
           docker-compose -f docker-compose.yml \
           -f docker-compose.dev.yml \
+          -f docker-compose.prod.yml \
           -f docker/compose/docker-compose.llama-1b-gpu.ci.yml \
           up -d
           docker ps -a
@@ -130,6 +131,7 @@ jobs:
         run: |
           docker-compose -f docker-compose.yml \
           -f docker-compose.dev.yml \
+          -f docker-compose.prod.yml \
           -f docker/compose/docker-compose.llama-1b-gpu.ci.yml \
           down -v
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@ nilAI is a platform designed to run on Confidential VMs with Trusted Execution E
 
 1. **Environment Setup**
    - Copy the `.env.sample` file to `.env`
-   - Replace `HUGGINGFACE_API_TOKEN` with your Hugging Face API token
-   - Obtain token by requesting access on the specific model's [Hugging Face page](https://huggingface.co/meta-llama/Llama-3.2-1B)
+   ```shell
+   cp .env.sample .env
+   ```
+   - Update the environment variables in `.env`:
+     - `HUGGINGFACE_API_TOKEN`: Your Hugging Face API token
+   - Obtain Hugging Face token by requesting access on the specific model's [Hugging Face page](https://huggingface.co/meta-llama/Llama-3.2-1B)
 
 ## Deployment Options
 
@@ -30,13 +34,17 @@ docker build -t nillion/nilai-api:latest -f docker/api.Dockerfile --target nilai
 Then, to deploy:
 
 ```shell
+# Deploy with CPU-only configuration
 docker compose -f docker-compose.yml \
   -f docker-compose.dev.yml \
-  -f docker/compose/docker-compose.llama-3b-gpu.yml \
-  -f docker/compose/docker-compose.llama-8b-gpu.yml \
-  -f docker/compose/docker-compose.dolphin-8b-gpu.yml \
-  -f docker/compose/docker-compose.deepseek-14b-gpu.yml \
-  up --build
+  -f docker/compose/docker-compose.llama-1b-cpu.yml \
+  up -d
+
+# Monitor logs
+docker compose -f docker-compose.yml \
+  -f docker-compose.dev.yml \
+  -f docker/compose/docker-compose.llama-1b-cpu.yml \
+  logs -f
 ```
 
 #### Production Environment
@@ -56,8 +64,7 @@ up -d
 ```
 **Note**: Remove lines for models you do not wish to deploy.
 
-For testing environment:
-
+#### Testing Without GPU
 ```shell
 # Build vLLM docker container
 docker build -t nillion/nilai-vllm:latest -f docker/vllm.Dockerfile .
@@ -72,7 +79,7 @@ docker compose -f docker-compose.yml \
 up -d
 ```
 
-### 2. Manual Deployment
+### 2. Manual Component Deployment
 
 #### Components
 
@@ -94,13 +101,16 @@ up -d
      -p 6379:6379 \
      redis:latest
 
-   docker run -d --name postgres \
-     -e POSTGRES_USER=user \
-     -e POSTGRES_PASSWORD=<ASECUREPASSWORD> \
-     -e POSTGRES_DB=yourdb \
-     -p 5432:5432 \
-     postgres:latest
-   ```
+# Start PostgreSQL
+docker run -d --name postgres \
+  -e POSTGRES_USER=${POSTGRES_USER} \
+  -e POSTGRES_PASSWORD=${POSTGRES_PASSWORD} \
+  -e POSTGRES_DB=${POSTGRES_DB} \
+  -p 5432:5432 \
+  --network frontend_net \
+  --volume postgres_data:/var/lib/postgresql/data \
+  postgres:16
+```
 
 2. **Run API Server**
    ```shell
@@ -133,21 +143,40 @@ uv run pre-commit install
 
 ## Model Lifecycle Management
 
-- Models register themselves in the etcd3 database
+- Models register themselves in the etcd database
 - Registration includes address information with an auto-expiring lifetime
 - If a model disconnects, it is automatically removed from the available models
 
 ## Security
 
 - Hugging Face API token controls model access
-- SQLite database manages user permissions
+- PostgreSQL database manages user permissions
 - Distributed architecture allows for flexible security configurations
 
 ## Troubleshooting
 
-- Ensure Hugging Face API token is valid
-- Check etcd3 and Docker container logs for connection issues
-- Verify network ports are not blocked or in use
+Common issues and solutions:
+
+1. **Container Logs**
+   ```shell
+   # View logs for all services
+   docker compose logs -f
+
+   # View logs for specific service
+   docker compose logs -f api
+   ```
+
+2. **Database Connection**
+   ```shell
+   # Check PostgreSQL connection
+   docker exec -it postgres psql -U ${POSTGRES_USER} -d ${POSTGRES_DB}
+   ```
+
+3. **Service Health**
+   ```shell
+   # Check service health status
+   docker compose ps
+   ```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ Then, to deploy:
 # Deploy with CPU-only configuration
 docker compose -f docker-compose.yml \
   -f docker-compose.dev.yml \
-  -f docker/compose/docker-compose.llama-1b-cpu.yml \
+  -f docker/compose/docker-compose.llama-1b-gpu.yml \
   up -d
 
 # Monitor logs
 docker compose -f docker-compose.yml \
   -f docker-compose.dev.yml \
-  -f docker/compose/docker-compose.llama-1b-cpu.yml \
+  -f docker/compose/docker-compose.llama-1b-gpu.yml \
   logs -f
 ```
 

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -3,8 +3,16 @@
 		protocols tls1.2 tls1.3
 	}
  }
- 
- https://test.nilai.sandbox.nilogy.xyz {
+
+{$NILAI_SERVER_DOMAIN} {
 	import ssl_config
-	reverse_proxy api:8443
+
+	handle_path /grafana/* {
+		uri strip_prefix /grafana
+		reverse_proxy grafana:3000
+	}
+
+	handle {
+		reverse_proxy api:8443
+	}
  }

--- a/docker-compose.dev.macos.yml
+++ b/docker-compose.dev.macos.yml
@@ -1,5 +1,6 @@
 services:
   api:
+    platform: linux/amd64
     ports:
       - "8080:8080"
       - "8443:8443"
@@ -11,6 +12,3 @@ services:
   postgres:
     ports:
       - "5432:5432"
-  grafana:
-    ports:
-      - "3000:3000"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,25 +1,9 @@
 services:
   api:
-    privileged: true
-    volumes:
-      - /dev/sev-guest:/dev/sev-guest # for AMD SEV
-    networks:
-      - proxy_net
-  caddy:
-    image: caddy:latest
-    container_name: caddy
-    restart: unless-stopped
-    networks:
-      - proxy_net
-    ports:
-      - "80:80"
-      - "443:443"
-      - "443:443/udp"
-    volumes:
-      - ./caddy/Caddyfile:/etc/caddy/Caddyfile
-      - ./caddy/caddy_data:/data
-      - ./caddy/caddy_config:/config
-networks:
-  # This network is meant to connect from the outside world to the API
-  ## This connects the API and Caddy
-  proxy_net:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,7 @@ services:
     restart: unless-stopped
     networks:
       - frontend_net
+      - proxy_net
     user: "$UID:$GID"
     depends_on:
       - prometheus
@@ -105,22 +106,19 @@ services:
   api:
     container_name: nilai-api
     image: nillion/nilai-api:latest
+    privileged: true
+    volumes:
+      - /dev/sev-guest:/dev/sev-guest # for AMD SEV
     depends_on:
       etcd:
         condition: service_healthy
       postgres:
         condition: service_healthy
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
     restart: unless-stopped
     networks:
       - frontend_net
       - backend_net
+      - proxy_net
     env_file:
       - .env
     healthcheck:
@@ -129,7 +127,20 @@ services:
       retries: 3
       start_period: 15s
       timeout: 10s
-
+  caddy:
+    image: caddy:latest
+    container_name: caddy
+    restart: unless-stopped
+    networks:
+      - proxy_net
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
+    volumes:
+      - ./caddy/Caddyfile:/etc/caddy/Caddyfile
+      - ./caddy/caddy_data:/data
+      - ./caddy/caddy_config:/config
 networks:
   # This is the network that is used for the "api" related services
   ## API, user management (postgres), caching (redis) and monitoring (prometheus, grafana)
@@ -137,6 +148,9 @@ networks:
   # This is the network that is used for the model related services:
   ## API, models, and etcd
   backend_net:
+  # This network is meant to connect from the outside world to the API
+  ## This connects the API and Caddy
+  proxy_net:
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,12 +90,11 @@ services:
       - ${PWD}/grafana/runtime-data:/var/lib/grafana
       - ${PWD}/grafana/datasources/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml
       - ${PWD}/grafana/dashboards/filesystem.yml:/etc/grafana/provisioning/dashboards/filesystem.yml
+      - ${PWD}/grafana/config/grafana.ini:/etc/grafana/grafana.ini
     env_file:
       - .env
     environment:
       - GF_USERS_ALLOW_SIGN_UP=false
-    ports:
-      - "127.0.0.1:3000:3000"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
       interval: 30s
@@ -137,6 +136,8 @@ services:
       - "80:80"
       - "443:443"
       - "443:443/udp"
+    env_file:
+      - .env
     volumes:
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile
       - ./caddy/caddy_data:/data

--- a/docker/compose/docker-compose.llama-1b-cpu.yml
+++ b/docker/compose/docker-compose.llama-1b-cpu.yml
@@ -1,0 +1,39 @@
+services:
+  llama_1b_cpu:
+    image: nillion/nilai-vllm:latest
+    container_name: nilai-llama_1b_cpu
+    env_file:
+      - .env
+    restart: unless-stopped
+    depends_on:
+      etcd:
+        condition: service_healthy
+    command: >
+      --model meta-llama/Llama-3.2-1B-Instruct
+      --gpu-memory-utilization 0.5
+      --max-model-len 30000
+      --tensor-parallel-size 1
+      --enable-auto-tool-choice
+      --tool-call-parser llama3_json
+      --uvicorn-log-level warning
+    environment:
+      - SVC_HOST=llama_1b_cpu
+      - SVC_PORT=8000
+      - ETCD_HOST=etcd
+      - ETCD_PORT=2379
+      - TOOL_SUPPORT=true
+    volumes:
+      - hugging_face_models:/root/.cache/huggingface  # cache models
+    networks:
+      - backend_net
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      retries: 3
+      start_period: 60s
+      timeout: 10s
+volumes:
+  hugging_face_models:
+
+networks:
+  backend_net:

--- a/grafana/config/grafana.ini
+++ b/grafana/config/grafana.ini
@@ -1,0 +1,3 @@
+[server]
+domain = ${NILAI_SERVER_DOMAIN}
+root_url = %(protocol)s://%(domain)s/grafana/

--- a/grafana/datasources/datasource.yml
+++ b/grafana/datasources/datasource.yml
@@ -9,3 +9,22 @@ datasources:
     isDefault: true
     # Fix the UID so we can provision dashboards that reference this.
     uid": "PBFA97CFB590B2093"
+
+  - name: PostgreSQL
+    type: postgres
+    access: proxy
+    orgId: 1
+    url: ${POSTGRES_HOST}:${POSTGRES_PORT}
+    isDefault: false
+    uid: "eehsf95n2at4we"
+    database: ${POSTGRES_DB}
+    user: ${POSTGRES_USER}
+    secureJsonData:
+      password: ${POSTGRES_PASSWORD}
+    jsonData:
+      sslmode: 'disable'
+      maxOpenConns: 100
+      maxIdleConns: 100
+      connMaxLifetime: 14400
+      postgresVersion: 1200
+      timescaledb: false

--- a/grafana/runtime-data/dashboards/nilai-api.json
+++ b/grafana/runtime-data/dashboards/nilai-api.json
@@ -22,12 +22,110 @@
   "links": [],
   "panels": [
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#1F78C1",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisBorderShow": true,
+            "axisCenteredZero": false,
+            "axisColorMode": "fixed",
+            "axisLabel": "Response Time (s)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 8,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "always",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(http_request_duration_seconds_sum{handler=\"/v1/chat/completions\", method=\"POST\"}[5m])\n/\nrate(http_request_duration_seconds_count{handler=\"/v1/chat/completions\", method=\"POST\"}[5m])",
+          "legendFormat": "Latency",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Latency for /v1/chat/completions",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 8
       },
       "id": 3,
       "panels": [],
@@ -99,7 +197,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 1
+        "y": 9
       },
       "id": 1,
       "options": {
@@ -198,7 +296,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 1
+        "y": 9
       },
       "id": 2,
       "options": {
@@ -233,7 +331,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 9
+        "y": 17
       },
       "id": 4,
       "panels": [],
@@ -305,7 +403,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 10
+        "y": 18
       },
       "id": 5,
       "options": {
@@ -399,7 +497,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 10
+        "y": 18
       },
       "id": 6,
       "options": {
@@ -434,7 +532,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 26
       },
       "id": 7,
       "panels": [],
@@ -506,7 +604,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 19
+        "y": 27
       },
       "id": 8,
       "options": {
@@ -630,7 +728,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 19
+        "y": 27
       },
       "id": 9,
       "options": {
@@ -763,6 +861,6 @@
   "timezone": "browser",
   "title": "nilai-api",
   "uid": "cecdjxbuye60wa",
-  "version": 7,
+  "version": 1,
   "weekStart": ""
 }

--- a/grafana/runtime-data/dashboards/usage-data.json
+++ b/grafana/runtime-data/dashboards/usage-data.json
@@ -1,0 +1,475 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 2,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "PostgreSQL",
+        "uid": "eehsf95n2at4we"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "PostgreSQL",
+            "uid": "eehsf95n2at4we"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT date_trunc('minute', q.query_timestamp) AS \"time\", COUNT(q.id) AS \"Queries\"\nFROM query_logs q\nWHERE q.query_timestamp >= NOW() - INTERVAL '1 hour'\nGROUP BY date_trunc('minute', q.query_timestamp)\nORDER BY \"time\";",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Queries per Minute (Last Hour)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "PostgreSQL",
+        "uid": "eehsf95n2at4we"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "displayLabels": [
+          "percent"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "PostgreSQL",
+            "uid": "eehsf95n2at4we"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT q.model, COUNT(q.id) AS total_queries\nFROM query_logs q\nWHERE q.query_timestamp >= NOW() - INTERVAL '7 days'\nGROUP BY  q.model\nORDER BY total_queries DESC;",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "name": "COUNT",
+                "parameters": [
+                  {
+                    "name": "model",
+                    "type": "functionParameter"
+                  }
+                ],
+                "type": "function"
+              },
+              {
+                "parameters": [
+                  {
+                    "name": "model",
+                    "type": "functionParameter"
+                  }
+                ],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "name": "model",
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
+          "table": "query_logs"
+        }
+      ],
+      "title": "Models Used",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "PostgreSQL",
+        "uid": "eehsf95n2at4we"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 1,
+      "options": {
+        "displayLabels": [
+          "percent"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "PostgreSQL",
+            "uid": "eehsf95n2at4we"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT \n  u.email AS \"User ID\", \n  COUNT(q.id) AS \"Queries\" \nFROM query_logs q \nJOIN users u ON q.userid = u.userid\nWHERE q.query_timestamp >= NOW() - INTERVAL '1 hours'\nGROUP BY u.email;",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "alias": "\"User ID\"",
+                "parameters": [
+                  {
+                    "name": "userid",
+                    "type": "functionParameter"
+                  }
+                ],
+                "type": "function"
+              },
+              {
+                "alias": "\"Queries\"",
+                "name": "COUNT",
+                "parameters": [
+                  {
+                    "name": "id",
+                    "type": "functionParameter"
+                  }
+                ],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "name": "userid",
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
+          "table": "query_logs"
+        }
+      ],
+      "title": "Last Hour Queries",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "PostgreSQL",
+        "uid": "eehsf95n2at4we"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "Queries",
+                  "test2@test.com",
+                  "test1@test.com"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 2,
+      "options": {
+        "displayLabels": [
+          "percent"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "PostgreSQL",
+            "uid": "eehsf95n2at4we"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT \n  u.email AS \"User ID\", \n  COUNT(q.id) AS \"Queries\" \nFROM query_logs q \nJOIN users u ON q.userid = u.userid\nWHERE q.query_timestamp >= NOW() - INTERVAL '7 days'\nGROUP BY u.email;",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Last Week Queries",
+      "type": "piechart"
+    }
+  ],
+  "preload": false,
+  "refresh": "30m",
+  "schemaVersion": 40,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6M",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Postgres Metrics",
+  "uid": "cehsgvjycth4wf",
+  "version": 2,
+  "weekStart": ""
+}

--- a/nilai-api/src/nilai_api/app.py
+++ b/nilai-api/src/nilai_api/app.py
@@ -100,3 +100,4 @@ app.add_middleware(
     allow_headers=["*"],
 )
 Instrumentator().instrument(app).expose(app)
+# Instrumentator().instrument(app).expose(app, include_in_schema=False)

--- a/nilai-api/src/nilai_api/app.py
+++ b/nilai-api/src/nilai_api/app.py
@@ -99,5 +99,4 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-Instrumentator().instrument(app).expose(app)
-# Instrumentator().instrument(app).expose(app, include_in_schema=False)
+Instrumentator().instrument(app).expose(app, include_in_schema=False)


### PR DESCRIPTION
This PR adds Grafana dashboards to monitor usage of the nilAI platform. This uses the PostgresDB platform to extract metrics. The refresh is set to 30 minutes because it's unnecessary to make queries any more often.

We also modify some docker-compose files to make sure that everything is working appropriately. 

- We move Caddy over to the main docker compose, as it can be used in localhost, and it doesn't make sense to have it split.
- We create docker-compose.macos.yml to be able to produce a deployment that works on macOS.
- We remove the GPU requirement on the nilai-api from the base docker-compose, and add it only on the prod instance, as it is assumed that users will not require it when developing locally.