### PR TITLE
fix: .env file clarifications and grafana access

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -8,6 +8,10 @@ HF_TOKEN="Hugging Face API Token"
 
 ENVIRONMENT = "mainnet"
 NILAI_GUNICORN_WORKERS = 10
+
+# The domain name of the server
+# - It must be written as "localhost" or "test.nilai.nillion"
+# - Do not put "https://" or "http://" in the domain name or / at the end
 NILAI_SERVER_DOMAIN = "localhost"
 
 

--- a/.env.sample
+++ b/.env.sample
@@ -8,6 +8,9 @@ HF_TOKEN="Hugging Face API Token"
 
 ENVIRONMENT = "mainnet"
 NILAI_GUNICORN_WORKERS = 10
+# The domain name of the server
+# - It must be written as "localhost" or "test.nilai.nillion"
+# - Do not put "https://" or "http://" in the domain name or / at the end
 NILAI_SERVER_DOMAIN = "localhost"
 
 

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -12,6 +12,11 @@
 		reverse_proxy grafana:3000
 	}
 
+	handle_path /grafana {
+		uri strip_prefix /grafana
+		reverse_proxy grafana:3000
+	}
+
 	handle {
 		reverse_proxy api:8443
 	}


### PR DESCRIPTION
This PR adds a clarification to a .env error where by setting up a domain like `https://test.nilai.nillion.com` or ending it in `/` would prevent from accessing subdomains.

Additionally, we add the /grafana domain redirection which was only available to subpaths before.