### PR TITLE
feat: allow all CORS origins

### DIFF
--- a/nilai-api/src/nilai_api/app.py
+++ b/nilai-api/src/nilai_api/app.py
@@ -88,14 +88,10 @@ app = FastAPI(
 app.include_router(public.router)
 app.include_router(private.router, dependencies=[Depends(get_auth_info)])
 
-origins = [
-    "https://docs.nillion.com",  # TODO: When users want to connect from browser
-]
-
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,
-    allow_credentials=True,
+    allow_origins=["*"],
+    allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
This PR allows all CORS origin to allow browser client side to connect to nilAI.