### PR TITLE
chore: Update to rc version of nuc-py

### DIFF
--- a/nilai-api/pyproject.toml
+++ b/nilai-api/pyproject.toml
@@ -43,4 +43,4 @@ build-backend = "hatchling.build"
 [tool.uv.sources]
 nilai-common = { workspace = true }
 nuc-helpers = { workspace = true }
-nuc = { git = "https://github.com/NillionNetwork/nuc-py.git", tag = "4922b5e9354e611cc31322d681eb29da05be584e" }
+nuc = { git = "https://github.com/NillionNetwork/nuc-py.git", tag = "54c7171e0e30fc9a68ba9e307bb6e92a0690f4d8" }

--- a/nilai-auth/nuc-helpers/pyproject.toml
+++ b/nilai-auth/nuc-helpers/pyproject.toml
@@ -20,4 +20,4 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.uv.sources]
-nuc = { git = "https://github.com/NillionNetwork/nuc-py.git", tag = "4922b5e9354e611cc31322d681eb29da05be584e" }
+nuc = { git = "https://github.com/NillionNetwork/nuc-py.git", tag = "54c7171e0e30fc9a68ba9e307bb6e92a0690f4d8" }


### PR DESCRIPTION
This PR updates to rc 2 of `nuc-py` with the latest changes to timestamps in nucs.