### PR TITLE
fix: migration to set default limits based on environment variables

### DIFF
--- a/nilai-api/alembic/versions/da89d3230653_create_initial_set_of_tables.py
+++ b/nilai-api/alembic/versions/da89d3230653_create_initial_set_of_tables.py
@@ -10,6 +10,11 @@ from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
+from nilai_api.config import (
+    USER_RATE_LIMIT_MINUTE,
+    USER_RATE_LIMIT_HOUR,
+    USER_RATE_LIMIT_DAY,
+)
 
 
 # revision identifiers, used by Alembic.
@@ -33,9 +38,18 @@ def upgrade() -> None:
             "signup_date", sa.DateTime, server_default=sa.func.now(), nullable=False
         ),
         sa.Column("last_activity", sa.DateTime, nullable=True),
-        sa.Column("ratelimit_day", sa.Integer, default=1000, nullable=True),
-        sa.Column("ratelimit_hour", sa.Integer, default=100, nullable=True),
-        sa.Column("ratelimit_minute", sa.Integer, default=10, nullable=True),
+        sa.Column(
+            "ratelimit_day", sa.Integer, default=USER_RATE_LIMIT_DAY, nullable=True
+        ),
+        sa.Column(
+            "ratelimit_hour", sa.Integer, default=USER_RATE_LIMIT_HOUR, nullable=True
+        ),
+        sa.Column(
+            "ratelimit_minute",
+            sa.Integer,
+            default=USER_RATE_LIMIT_MINUTE,
+            nullable=True,
+        ),
     )
     op.create_table(
         "query_logs",

--- a/nilai-api/src/nilai_api/config/__init__.py
+++ b/nilai-api/src/nilai_api/config/__init__.py
@@ -1,31 +1,38 @@
 import os
+from typing import List
 
 from dotenv import load_dotenv
 
 load_dotenv()
 
-ENVIRONMENT = os.getenv("ENVIRONMENT", "testnet")
+ENVIRONMENT: str = os.getenv("ENVIRONMENT", "testnet")
 
 
-ETCD_HOST = os.getenv("ETCD_HOST", "localhost")
-ETCD_PORT = int(os.getenv("ETCD_PORT", 2379))
+ETCD_HOST: str = os.getenv("ETCD_HOST", "localhost")
+ETCD_PORT: int = int(os.getenv("ETCD_PORT", 2379))
 
 
-REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
+REDIS_URL: str = os.getenv("REDIS_URL", "redis://localhost:6379")
 
-DOCS_TOKEN = os.getenv("DOCS_TOKEN", None)
+DOCS_TOKEN: str | None = os.getenv("DOCS_TOKEN", None)
 
-DB_USER = os.getenv("POSTGRES_USER", "postgres")
-DB_PASS = os.getenv("POSTGRES_PASSWORD", "")
-DB_HOST = os.getenv("POSTGRES_HOST", "localhost")
-DB_PORT = int(os.getenv("POSTGRES_PORT", 5432))
-DB_NAME = os.getenv("POSTGRES_DB", "nilai_users")
+DB_USER: str = os.getenv("POSTGRES_USER", "postgres")
+DB_PASS: str = os.getenv("POSTGRES_PASSWORD", "")
+DB_HOST: str = os.getenv("POSTGRES_HOST", "localhost")
+DB_PORT: int = int(os.getenv("POSTGRES_PORT", 5432))
+DB_NAME: str = os.getenv("POSTGRES_DB", "nilai_users")
 
 
-NILAUTH_TRUSTED_ROOT_ISSUERS = os.getenv("NILAUTH_TRUSTED_ROOT_ISSUERS", "").split(",")
+NILAUTH_TRUSTED_ROOT_ISSUERS: List[str] = os.getenv(
+    "NILAUTH_TRUSTED_ROOT_ISSUERS", ""
+).split(",")
 
-AUTH_STRATEGY = os.getenv("AUTH_STRATEGY", "api_key")
+AUTH_STRATEGY: str = os.getenv("AUTH_STRATEGY", "api_key")
 
+# Defined by default but re-defined in testnet.py and mainnet.py
+USER_RATE_LIMIT_MINUTE: int | None = 100
+USER_RATE_LIMIT_HOUR: int | None = 1000
+USER_RATE_LIMIT_DAY: int | None = 10000
 
 if ENVIRONMENT == "mainnet":
     from .mainnet import *  # noqa


### PR DESCRIPTION
This PR fixes default rate limits on images. Before, with the construction based on custom environments, it didn't affect, but it does now.