### PR TITLE
fix: added specific mountpoint for api-specific config files

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,3 +7,5 @@ services:
             - driver: nvidia
               count: all
               capabilities: [gpu]
+    volumes:
+      - /dev/sev-guest:/dev/sev-guest # for AMD SEV

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,7 +128,7 @@ services:
     image: nillion/nilai-api:latest
     privileged: true
     volumes:
-      - /dev/sev-guest:/dev/sev-guest # for AMD SEV
+      - ./nilai-api/src/nilai_api/config/:/app/nilai-api/src/nilai_api/config/
     depends_on:
       etcd:
         condition: service_healthy
@@ -152,7 +152,7 @@ services:
     image: nillion/nilai-api:latest
     privileged: true
     volumes:
-      - /dev/sev-guest:/dev/sev-guest # for AMD SEV
+      - ./nilai-api/src/nilai_api/config/:/app/nilai-api/src/nilai_api/config/
     depends_on:
       etcd:
         condition: service_healthy


### PR DESCRIPTION
This PR fixes a bug where nilAI may not mount the directory where the config is overwritten on the host when dealing with pre-compiled images. This adds a mountpoint to the default docker-compose to ensure that the latest configs are present. It also adds a /dev/sev-guest mountpoint to the attestation endpoint.