### PR TITLE
Fix: add sources after web search in stream mode

### DIFF
--- a/tests/unit/nilai_api/routers/test_private.py
+++ b/tests/unit/nilai_api/routers/test_private.py
@@ -321,9 +321,9 @@ def test_chat_completion_stream_includes_sources(
         ]
 
     assert data_lines, "Expected SSE data from stream response"
-    first_payload = json.loads(data_lines[0][len("data: "):])
+    first_payload = json.loads(data_lines[0][len("data: ") :])
     assert "sources" not in first_payload
-    final_payload = json.loads(data_lines[-1][len("data: "):])
+    final_payload = json.loads(data_lines[-1][len("data: ") :])
     assert "sources" in final_payload
     assert len(final_payload["sources"]) == 1
     assert final_payload["sources"][0]["source"] == "https://example.com"

--- a/tests/unit/nilai_api/routers/test_private.py
+++ b/tests/unit/nilai_api/routers/test_private.py
@@ -1,11 +1,12 @@
 import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
 
 from nilai_api.db.users import RateLimits, UserModel
-from nilai_common import AttestationReport
+from nilai_common import AttestationReport, Source
 
 from nilai_api.state import state
 from ... import model_endpoint, model_metadata, response as RESPONSE
@@ -221,3 +222,108 @@ def test_chat_completion(mock_user, mock_state, mock_user_manager, mocker, clien
         "completion_tokens_details": None,
         "prompt_tokens_details": None,
     }
+
+
+def test_chat_completion_stream_includes_sources(
+    mock_user, mock_state, mock_user_manager, mocker, client
+):
+    source = Source(source="https://example.com", content="Example result")
+
+    mock_web_search_result = MagicMock()
+    mock_web_search_result.messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Tell me something new."},
+    ]
+    mock_web_search_result.sources = [source]
+
+    mocker.patch(
+        "nilai_api.routers.private.handle_web_search",
+        new=AsyncMock(return_value=mock_web_search_result),
+    )
+
+    class MockChunk:
+        def __init__(self, data, usage=None):
+            self._data = data
+            self.usage = usage
+
+        def model_dump(self, exclude_unset=True):
+            return self._data
+
+    class MockUsage:
+        def __init__(self, prompt_tokens: int, completion_tokens: int):
+            self.prompt_tokens = prompt_tokens
+            self.completion_tokens = completion_tokens
+
+    first_chunk = MockChunk(
+        data={
+            "id": "stream-1",
+            "object": "chat.completion.chunk",
+            "model": "meta-llama/Llama-3.2-1B-Instruct",
+            "created": 0,
+            "choices": [{"delta": {"content": "Hello"}, "index": 0}],
+        }
+    )
+
+    final_chunk = MockChunk(
+        data={
+            "id": "stream-1",
+            "object": "chat.completion.chunk",
+            "model": "meta-llama/Llama-3.2-1B-Instruct",
+            "created": 0,
+            "choices": [
+                {"delta": {}, "finish_reason": "stop", "index": 0},
+            ],
+            "usage": {
+                "prompt_tokens": 5,
+                "completion_tokens": 7,
+                "total_tokens": 12,
+            },
+        },
+        usage=MockUsage(prompt_tokens=5, completion_tokens=7),
+    )
+
+    async def chunk_generator():
+        yield first_chunk
+        yield final_chunk
+
+    mock_chat_completions = MagicMock()
+    mock_chat_completions.create = AsyncMock(return_value=chunk_generator())
+    mock_chat = MagicMock()
+    mock_chat.completions = mock_chat_completions
+    mock_async_openai_instance = MagicMock()
+    mock_async_openai_instance.chat = mock_chat
+
+    mocker.patch(
+        "nilai_api.routers.private.AsyncOpenAI",
+        return_value=mock_async_openai_instance,
+    )
+
+    payload = {
+        "model": "meta-llama/Llama-3.2-1B-Instruct",
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Tell me something new."},
+        ],
+        "stream": True,
+        "web_search": True,
+    }
+
+    headers = {"Authorization": "Bearer test-api-key"}
+
+    with client.stream(
+        "POST", "/v1/chat/completions", json=payload, headers=headers
+    ) as response:
+        assert response.status_code == 200
+        data_lines = [
+            line
+            for line in response.iter_lines(decode_unicode=True)
+            if line and line.startswith("data: ")
+        ]
+
+    assert data_lines, "Expected SSE data from stream response"
+    first_payload = json.loads(data_lines[0][len("data: "):])
+    assert "sources" not in first_payload
+    final_payload = json.loads(data_lines[-1][len("data: "):])
+    assert "sources" in final_payload
+    assert len(final_payload["sources"]) == 1
+    assert final_payload["sources"][0]["source"] == "https://example.com"


### PR DESCRIPTION
This pull request fixes the streaming chat completion endpoint to include sources when web search is on. It also adds a unit test to verify that sources are properly included in the final streamed payload.

**Streaming response improvements:**

* Refactored the streaming logic in `chat_completion_stream_generator` to buffer payloads, append sources only on the final chunk (when `finish_reason == "stop"`), and yield JSON-encoded SSE events; also improved token usage tracking and error handling in the stream. [[1]](diffhunk://#diff-d8841f9483e9880dc19865c939c3cc109d51e63dac45545873f591df52fa4a7fL309-R323) [[2]](diffhunk://#diff-d8841f9483e9880dc19865c939c3cc109d51e63dac45545873f591df52fa4a7fL330-R373) [[3]](diffhunk://#diff-d8841f9483e9880dc19865c939c3cc109d51e63dac45545873f591df52fa4a7fL362-R406)

**Testing enhancements:**

* Added a new unit test `test_chat_completion_stream_includes_sources` to verify that web search sources are only included in the final streamed payload, ensuring correct SSE formatting and payload structure.

**Code cleanup:**

* Removed unused imports (`asyncio`) and added necessary ones (`json`) in both the main router and test files. [[1]](diffhunk://#diff-d8841f9483e9880dc19865c939c3cc109d51e63dac45545873f591df52fa4a7fL2-R2) [[2]](diffhunk://#diff-bcc98ed80720c4c3a856b6c20d7aeaf36fffdeb709a90789e94f081acf2f8aabR2-R9)