### PR TITLE
fix: align default pricing values with config.yaml

### DIFF
--- a/nilai-api/src/nilai_api/config/pricing.py
+++ b/nilai-api/src/nilai_api/config/pricing.py
@@ -6,10 +6,10 @@ class LLMPriceConfig(BaseModel):
     """Pricing configuration for a single LLM model."""
 
     prompt_tokens_price: float = Field(
-        default=2.0, description="Cost per 1M prompt tokens"
+        default=0.15, description="Cost per 1M prompt tokens"
     )
     completion_tokens_price: float = Field(
-        default=2.0, description="Cost per 1M completion tokens"
+        default=0.45, description="Cost per 1M completion tokens"
     )
     web_search_cost: float = Field(default=0.05, description="Cost per web search")
 


### PR DESCRIPTION
## Summary
- Changed `LLMPriceConfig` hardcoded defaults from `2.0`/`2.0` to `0.15`/`0.45` for `prompt_tokens_price` and `completion_tokens_price` respectively
- These defaults now match `config.yaml` and the values expected by e2e pricing tests (`test_pricing.py`)
- `web_search_cost` default was already correct at `0.05`

## Test plan
- [x] Rust workspace checks pass (`cargo check`, `cargo clippy`, `cargo test`)
- [ ] E2e pricing tests pass (requires Docker services)

🤖 Generated with [Claude Code](https://claude.com/claude-code)