### PR TITLE
fix: Dockerfile Rust 1.88 and pricing route axum 0.8 compat

### DIFF
--- a/crates/nilai-api/src/routes/pricing.rs
+++ b/crates/nilai-api/src/routes/pricing.rs
@@ -12,7 +12,7 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .route("/v1/pricing", get(get_all_prices))
         .route(
-            "/v1/pricing/*model_name",
+            "/v1/pricing/{*model_name}",
             get(get_price).put(set_price).delete(delete_price),
         )
 }
@@ -41,6 +41,8 @@ async fn get_price(
     State(state): State<AppState>,
     Path(model_name): Path<String>,
 ) -> Result<Json<LLMPriceConfig>, (StatusCode, Json<serde_json::Value>)> {
+    let model_name = model_name.strip_prefix('/').unwrap_or(&model_name);
+
     let store = state.pricing_store.as_ref().ok_or_else(|| {
         (
             StatusCode::SERVICE_UNAVAILABLE,
@@ -49,7 +51,7 @@ async fn get_price(
     })?;
 
     let price = store
-        .get_price(&ModelName::new(&model_name))
+        .get_price(&ModelName::new(model_name))
         .await
         .map_err(|e| {
             (
@@ -67,6 +69,8 @@ async fn set_price(
     headers: HeaderMap,
     Json(config): Json<LLMPriceConfig>,
 ) -> Result<Json<LLMPriceConfig>, (StatusCode, Json<serde_json::Value>)> {
+    let model_name = model_name.strip_prefix('/').unwrap_or(&model_name);
+
     // Verify admin token
     verify_admin_token(&state, &headers)?;
 
@@ -89,7 +93,7 @@ async fn set_price(
     })?;
 
     store
-        .set_price(&ModelName::new(&model_name), &config)
+        .set_price(&ModelName::new(model_name), &config)
         .await
         .map_err(|e| {
             (
@@ -106,6 +110,8 @@ async fn delete_price(
     Path(model_name): Path<String>,
     headers: HeaderMap,
 ) -> Result<StatusCode, (StatusCode, Json<serde_json::Value>)> {
+    let model_name = model_name.strip_prefix('/').unwrap_or(&model_name);
+
     verify_admin_token(&state, &headers)?;
 
     if model_name == "default" {
@@ -123,7 +129,7 @@ async fn delete_price(
     })?;
 
     let existed = store
-        .delete_price(&ModelName::new(&model_name))
+        .delete_price(&ModelName::new(model_name))
         .await
         .map_err(|e| {
             (

--- a/docker/nilai-api.Dockerfile
+++ b/docker/nilai-api.Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM rust:1.80-bookworm AS builder
+FROM rust:1.88-bookworm AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Bump Rust base image in `docker/nilai-api.Dockerfile` from 1.80 to 1.88 (required by edition2024, darling 0.23, serde_with 3.18, time 0.3.47)
- Update pricing wildcard route from `*model_name` to `{*model_name}` for axum 0.8 compatibility
- Strip leading `/` from captured wildcard path in all 3 pricing handlers (`get_price`, `set_price`, `delete_price`)

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes (3/3 tests, all 11 suites)
- [ ] E2e tests (requires Docker services, to be validated in full integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)