### PR TITLE
fix: return flat JSON list from /v1/models endpoint

### DIFF
--- a/crates/nilai-api/src/routes/models.rs
+++ b/crates/nilai-api/src/routes/models.rs
@@ -24,8 +24,5 @@ async fn list_models(
 
     let data: Vec<_> = models.values().map(|ep| &ep.metadata).collect();
 
-    Ok(Json(serde_json::json!({
-        "object": "list",
-        "data": data
-    })))
+    Ok(Json(serde_json::json!(data)))
 }


### PR DESCRIPTION
## Summary
- Changed `/v1/models` endpoint to return a flat JSON array of model objects instead of an OpenAI-style `{"object": "list", "data": [...]}` wrapper.
- The e2e test (`test_models_endpoint`) asserts `isinstance(response.json(), list)` and reads `model.get("id")` directly from items, so the response must be a plain list.
- `ModelMetadata` already has an `id` field, so no domain changes were needed.

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes (3/3 tests)
- [ ] e2e tests (requires Docker services — to be verified in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)