### PR TITLE
fix: align credit service client with nilauth-credit API

### DIFF
--- a/crates/nilai-api/src/main.rs
+++ b/crates/nilai-api/src/main.rs
@@ -225,10 +225,7 @@ fn wire_credit_service(
 ) -> Option<Arc<dyn nilai_domain::ports::CreditService>> {
     if let Some(url) = config.auth.credit_service_url() {
         Some(Arc::new(
-            nilai_infra::http::credit_client::NilauthCreditClient::new(
-                url.to_string(),
-                config.auth.credit_api_token.clone(),
-            ),
+            nilai_infra::http::credit_client::NilauthCreditClient::new(url.to_string()),
         ))
     } else {
         tracing::warn!("No credit service URL configured");

--- a/crates/nilai-api/src/middleware/metering.rs
+++ b/crates/nilai-api/src/middleware/metering.rs
@@ -1,5 +1,5 @@
 use nilai_domain::error::NilaiResult;
-use nilai_domain::ids::{Credits, LockId, UserId};
+use nilai_domain::ids::{ApiKey, Credits, LockId};
 use nilai_domain::ports::CreditService;
 use std::sync::Arc;
 
@@ -8,15 +8,21 @@ use std::sync::Arc;
 pub struct MeteringContext {
     credit_service: Arc<dyn CreditService>,
     lock_id: Option<LockId>,
-    user_id: UserId,
+    credential: ApiKey,
+    is_public: bool,
 }
 
 impl MeteringContext {
-    pub fn new(credit_service: Arc<dyn CreditService>, user_id: UserId) -> Self {
+    pub fn new(
+        credit_service: Arc<dyn CreditService>,
+        credential: ApiKey,
+        is_public: bool,
+    ) -> Self {
         Self {
             credit_service,
             lock_id: None,
-            user_id,
+            credential,
+            is_public,
         }
     }
 
@@ -24,7 +30,11 @@ impl MeteringContext {
     pub async fn lock(&mut self, estimated_cost: f64) -> NilaiResult<()> {
         let lock_id = self
             .credit_service
-            .lock_credits(&self.user_id, Credits::new(estimated_cost))
+            .lock_credits(
+                &self.credential,
+                Credits::new(estimated_cost),
+                self.is_public,
+            )
             .await?;
         self.lock_id = Some(lock_id);
         Ok(())

--- a/crates/nilai-domain/src/ports/credit_service.rs
+++ b/crates/nilai-domain/src/ports/credit_service.rs
@@ -10,6 +10,11 @@ pub trait CreditService: Send + Sync {
         credential: &ApiKey,
         is_public: bool,
     ) -> NilaiResult<UserId>;
-    async fn lock_credits(&self, user_id: &UserId, estimated_cost: Credits) -> NilaiResult<LockId>;
+    async fn lock_credits(
+        &self,
+        credential: &ApiKey,
+        estimated_cost: Credits,
+        is_public: bool,
+    ) -> NilaiResult<LockId>;
     async fn settle_credits(&self, lock_id: &LockId, actual_cost: Credits) -> NilaiResult<()>;
 }

--- a/crates/nilai-infra/src/http/credit_client.rs
+++ b/crates/nilai-infra/src/http/credit_client.rs
@@ -8,18 +8,16 @@ use nilai_domain::ports::CreditService;
 pub struct NilauthCreditClient {
     client: Client,
     base_url: String,
-    api_token: String,
 }
 
 impl NilauthCreditClient {
-    pub fn new(base_url: String, api_token: String) -> Self {
+    pub fn new(base_url: String) -> Self {
         Self {
             client: Client::builder()
                 .timeout(std::time::Duration::from_secs(10))
                 .build()
                 .unwrap_or_default(),
             base_url,
-            api_token,
         }
     }
 }
@@ -31,13 +29,11 @@ impl CreditService for NilauthCreditClient {
         credential: &ApiKey,
         is_public: bool,
     ) -> NilaiResult<UserId> {
-        // TODO: Reverse-engineer the exact nilauth-credit-middleware HTTP protocol
         let resp = self
             .client
-            .post(format!("{}/validate", self.base_url))
-            .header("Authorization", format!("Bearer {}", self.api_token))
+            .post(format!("{}/v1/credential/validate", self.base_url))
             .json(&serde_json::json!({
-                "credential": credential.as_str(),
+                "credential_key": credential.as_str(),
                 "is_public": is_public,
             }))
             .send()
@@ -54,6 +50,10 @@ impl CreditService for NilauthCreditClient {
         #[derive(serde::Deserialize)]
         struct ValidateResponse {
             user_id: String,
+            #[allow(dead_code)]
+            is_valid: bool,
+            #[allow(dead_code)]
+            is_public: bool,
         }
 
         let body: ValidateResponse =
@@ -65,15 +65,24 @@ impl CreditService for NilauthCreditClient {
         Ok(UserId::new(body.user_id))
     }
 
-    async fn lock_credits(&self, user_id: &UserId, estimated_cost: Credits) -> NilaiResult<LockId> {
-        // TODO: Reverse-engineer the exact lock protocol
+    async fn lock_credits(
+        &self,
+        credential: &ApiKey,
+        estimated_cost: Credits,
+        is_public: bool,
+    ) -> NilaiResult<LockId> {
+        let endpoint = if is_public {
+            "v1/balance/lock/public"
+        } else {
+            "v1/balance/lock/private"
+        };
+
         let resp = self
             .client
-            .post(format!("{}/lock", self.base_url))
-            .header("Authorization", format!("Bearer {}", self.api_token))
+            .post(format!("{}/{}", self.base_url, endpoint))
             .json(&serde_json::json!({
-                "user_id": user_id.as_str(),
-                "estimated_cost": estimated_cost.as_f64(),
+                "credential": credential.as_str(),
+                "amount": estimated_cost.as_f64(),
             }))
             .send()
             .await
@@ -81,6 +90,13 @@ impl CreditService for NilauthCreditClient {
                 service: "nilauth".to_string(),
                 message: format!("Lock credits failed: {}", e),
             })?;
+
+        if !resp.status().is_success() {
+            return Err(NilaiError::ExternalService {
+                service: "nilauth".to_string(),
+                message: "Lock credits failed".to_string(),
+            });
+        }
 
         #[derive(serde::Deserialize)]
         struct LockResponse {
@@ -96,14 +112,12 @@ impl CreditService for NilauthCreditClient {
     }
 
     async fn settle_credits(&self, lock_id: &LockId, actual_cost: Credits) -> NilaiResult<()> {
-        // TODO: Reverse-engineer the exact settle protocol
         let resp = self
             .client
-            .post(format!("{}/settle", self.base_url))
-            .header("Authorization", format!("Bearer {}", self.api_token))
+            .post(format!("{}/v1/balance/unlock", self.base_url))
             .json(&serde_json::json!({
                 "lock_id": lock_id.as_str(),
-                "actual_cost": actual_cost.as_f64(),
+                "real_cost": actual_cost.as_f64(),
             }))
             .send()
             .await


### PR DESCRIPTION
## Summary
- Fix credit client HTTP endpoints to match actual nilauth-credit API (`/v1/credential/validate`, `/v1/balance/lock/{public,private}`, `/v1/balance/unlock`)
- Fix request body field names (`credential_key`, `credential`, `amount`, `real_cost`)
- Update `CreditService::lock_credits` trait signature to accept `credential` + `is_public` instead of `user_id` (the nilauth API authenticates via credential keys in request bodies)
- Remove unused Bearer token authentication from the credit client
- Update `MeteringContext` to carry credential and is_public instead of user_id

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes (3 tests)
- [x] `cargo fmt` and `cargo clippy` clean
- [ ] E2E tests (require Docker services, tested by coordinator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)